### PR TITLE
Update generateCentreonHoverGraph.php

### DIFF
--- a/generateCentreonHoverGraph.php
+++ b/generateCentreonHoverGraph.php
@@ -27,6 +27,7 @@ switch($_GET['action']) {
 		AND index_data.host_id = " . $pearDB->escape($_GET['host_id']) . "
 		AND metrics.index_id = index_data.id 
 		AND index_data.service_id = services.service_id 
+                AND services.host_id = " . $pearDB->escape($_GET['host_id']) . "
 		AND metrics.metric_name LIKE '%traffic%'
 		GROUP BY metrics.metric_id
 		ORDER BY metrics.metric_id";


### PR DESCRIPTION
Sometimes service ID is the same for multiple hosts, so the service description returned by the SQL query is not the good one.

example : 
```

MariaDB [centreon_storage]> select * from services where service_id=1958;
+---------+----------------------------+------------+--------------+----------------------+------------+---------------+---------------+----------------------------------------------+------>
| host_id | description                | service_id | acknowledged | acknowledgement_type | action_url | active_checks | check_attempt | check_command                                | check>
+---------+----------------------------+------------+--------------+----------------------+------------+---------------+---------------+----------------------------------------------+------>
|     124 | hp-pa2-bas-33              |       1958 |            0 |                    0 |            |             1 |             1 | centreonplugin_check_hp_switch_traffic!60!80 |      >
|     278 | n3k-ren-1 po7 / rtr-pub-01 |       1958 |            0 |                    0 |            |             1 |             1 | centreonplugin_check_cisco_traffic!60!80     |      >
 |              0 |                    0 | 'traffic_in'=90507296.80b/s;0:4500000000;0:5400000000;0;6000000000 'traffic_out'=63742330.13b/s;0:4500000000;0:5400000000;0;6000000000 |          >
+---------+----------------------------+------------+--------------+----------------------+------------+---------------+---------------+----------------------------------------------+--

```

in my case, the service_description returned was "hp-pa2-bas-33" instead of the good one "n3k-ren-1 po7 / rtr-pub-01"